### PR TITLE
Handle file enumeration without process substitution

### DIFF
--- a/renamer.sh
+++ b/renamer.sh
@@ -60,7 +60,10 @@ rename_files() {
 	num_files_renamed=0
 	num_files_unchanged=0
 
-        while IFS= read -r file; do
+        tmpfile=$(mktemp)
+        find . -type f -print0 > "$tmpfile"
+
+        while IFS= read -r -d '' file; do
                 timestamp=$(date +%s)
                 overlapfile=0
                 dir="${file%/*}"
@@ -126,7 +129,9 @@ rename_files() {
                 else
                         ((num_files_unchanged++))
                 fi
-        done < <(find . -type f)
+        done < "$tmpfile"
+
+        rm -f "$tmpfile"
 
 	echo "..."
 	echo "FILE RENAME COMPLETE"


### PR DESCRIPTION
## Summary
- replace the process substitution loop in `rename_files` with a portable `find` + temporary file approach
- keep the renaming counters working even when the script runs under shells that lack process substitution support

## Testing
- bash renamer.sh ./sample_files ./renamed_test

------
https://chatgpt.com/codex/tasks/task_e_68eb184c7664832a8acfe4831339a9d7