### PR TITLE
Skip renaming dotfiles during file rename

### DIFF
--- a/renamer.sh
+++ b/renamer.sh
@@ -69,9 +69,16 @@ rename_files() {
 		dir="${file%/*}"
 		oldname="${file##*/}"
 
-		truncated=${oldname:0:40}
+                truncated=${oldname:0:40}
 
-		if [[ "$oldname" == *.* && "$oldname" != .* ]]; then
+                # Skip hidden files that begin with a dot (e.g., .DS_Store, .htaccess)
+                # to avoid generating renamed copies of metadata files.
+                if [[ "$oldname" == .* && "$oldname" != "." && "$oldname" != ".." ]]; then
+                        ((num_files_unchanged++))
+                        continue
+                fi
+
+                if [[ "$oldname" == *.* && "$oldname" != .* ]]; then
 			base="${truncated%.*}"
 			extension=$(echo "${oldname##*.}" | tr '[:upper:]' '[:lower:]')
 		else


### PR DESCRIPTION
## Summary
- skip hidden dotfiles in the file renaming loop so metadata files like .DS_Store are left untouched

## Testing
- bash -n renamer.sh

------
https://chatgpt.com/codex/tasks/task_e_68eb292e7b6c832a8f2fdf09b8c40e3c