### PR TITLE
Skip renaming hidden files and directories

### DIFF
--- a/renamer.sh
+++ b/renamer.sh
@@ -61,13 +61,21 @@ rename_files() {
 	num_files_unchanged=0
 
 	tmpfile=$(mktemp)
-	find . -type f -print0 >"$tmpfile"
+        find . -type f -print0 >"$tmpfile"
 
-	while IFS= read -r -d '' file; do
-		timestamp=$(date +%s)
-		overlapfile=0
-		dir="${file%/*}"
-		oldname="${file##*/}"
+        while IFS= read -r -d '' file; do
+                timestamp=$(date +%s)
+                overlapfile=0
+                dir="${file%/*}"
+                oldname="${file##*/}"
+
+                # Skip any files that live inside hidden directories (paths containing
+                # a component that begins with a dot) so that metadata folders such as
+                # .git or macOS resource directories remain untouched.
+                if [[ "$file" == */.* ]]; then
+                        ((num_files_unchanged++))
+                        continue
+                fi
 
                 truncated=${oldname:0:40}
 


### PR DESCRIPTION
## Summary
- skip files located in hidden directories when renaming so metadata folders stay untouched
- continue counting hidden files as unchanged without attempting to sanitize their names

## Testing
- `tmpdir=$(mktemp -d) && mkdir -p "$tmpdir/src/.hidden" && touch "$tmpdir/src/.DS_Store" "$tmpdir/src/.hidden/file.txt" "$tmpdir/src/visible.txt" && bash renamer.sh "$tmpdir/src" "$tmpdir/dest"`


------
https://chatgpt.com/codex/tasks/task_e_68eb33e0dfc8832aa8ccb12ec1010251