### PR TITLE
Add file processing progress counter

### DIFF
--- a/renamer.sh
+++ b/renamer.sh
@@ -63,6 +63,11 @@ rename_files() {
 	tmpfile=$(mktemp)
 	find . -type f -print0 >"$tmpfile"
 
+	total_files=$(tr -cd '\0' <"$tmpfile" | wc -c)
+	processed_files=0
+
+	echo "0 out of $total_files files complete"
+
 	while IFS= read -r -d '' file; do
 		timestamp=$(date +%s)
 		overlapfile=0
@@ -74,18 +79,22 @@ rename_files() {
 		# .git or macOS resource directories remain untouched.
 		if [[ "$file" == */.* ]]; then
 			((num_files_unchanged++))
+			((processed_files++))
+			echo "$processed_files out of $total_files files complete"
 			continue
 		fi
-
+	
 		truncated=${oldname:0:40}
 
 		# Skip hidden files that begin with a dot (e.g., .DS_Store, .htaccess)
 		# to avoid generating renamed copies of metadata files.
 		if [[ "$oldname" == .* && "$oldname" != "." && "$oldname" != ".." ]]; then
 			((num_files_unchanged++))
+			((processed_files++))
+			echo "$processed_files out of $total_files files complete"
 			continue
 		fi
-
+	
 		if [[ "$oldname" == *.* && "$oldname" != .* ]]; then
 			base="${truncated%.*}"
 			extension=$(echo "${oldname##*.}" | tr '[:upper:]' '[:lower:]')
@@ -144,6 +153,8 @@ rename_files() {
 		else
 			((num_files_unchanged++))
 		fi
+		((processed_files++))
+		echo "$processed_files out of $total_files files complete"
 	done <"$tmpfile"
 
 	rm -f "$tmpfile"


### PR DESCRIPTION
## Summary
- count total files to be processed before renaming begins
- display a running "processed out of total" counter as each file (including skipped ones) is handled

## Testing
- bash -n renamer.sh

------
https://chatgpt.com/codex/tasks/task_e_68ec6f0bb6d0832a81d27e380f4b19aa