### PR TITLE
Add progress bar for file rename counter

### DIFF
--- a/renamer.sh
+++ b/renamer.sh
@@ -54,48 +54,87 @@ rename_dirs() {
 	fi
 }
 
+# Render a single-line progress bar showing how many files have been processed.
+print_progress_line() {
+        local processed=$1
+        local total=$2
+        local width=30
+        local filled=0
+        local empty=0
+        local percent=0
+
+        if [ "$total" -gt 0 ]; then
+                if [ "$processed" -gt "$total" ]; then
+                        processed=$total
+                fi
+                filled=$(( processed * width / total ))
+                percent=$(( processed * 100 / total ))
+        else
+                filled=$width
+                percent=100
+        fi
+
+        if [ "$filled" -gt "$width" ]; then
+                filled=$width
+        fi
+
+        empty=$(( width - filled ))
+
+        printf -v bar '%*s' "$filled" ""
+        bar=${bar// /#}
+
+        printf -v spaces '%*s' "$empty" ""
+        spaces=${spaces// /-}
+
+        printf '\r\033[KProgress: [%s%s] %3d%% (%d/%d)' "$bar" "$spaces" "$percent" "$processed" "$total"
+}
+
+clear_progress_line() {
+        printf '\r\033[K'
+}
+
 # Function to rename files
 rename_files() {
-	countfile=0
-	num_files_renamed=0
-	num_files_unchanged=0
+        countfile=0
+        num_files_renamed=0
+        num_files_unchanged=0
 
-	tmpfile=$(mktemp)
-	find . -type f -print0 >"$tmpfile"
+        tmpfile=$(mktemp)
+        find . -type f -print0 >"$tmpfile"
 
-	total_files=$(tr -cd '\0' <"$tmpfile" | wc -c)
-	processed_files=0
+        total_files=$(tr -cd '\0' <"$tmpfile" | wc -c)
+        processed_files=0
 
-	echo "0 out of $total_files files complete"
+        print_progress_line "$processed_files" "$total_files"
 
-	while IFS= read -r -d '' file; do
-		timestamp=$(date +%s)
-		overlapfile=0
-		dir="${file%/*}"
+        while IFS= read -r -d '' file; do
+                timestamp=$(date +%s)
+                overlapfile=0
+                dir="${file%/*}"
 		oldname="${file##*/}"
 
-		# Skip any files that live inside hidden directories (paths containing
-		# a component that begins with a dot) so that metadata folders such as
-		# .git or macOS resource directories remain untouched.
-		if [[ "$file" == */.* ]]; then
-			((num_files_unchanged++))
-			((processed_files++))
-			echo "$processed_files out of $total_files files complete"
-			continue
-		fi
+                # Skip any files that live inside hidden directories (paths containing
+                # a component that begins with a dot) so that metadata folders such as
+                # .git or macOS resource directories remain untouched.
+                if [[ "$file" == */.* ]]; then
+                        ((num_files_unchanged++))
+                        ((processed_files++))
+                        print_progress_line "$processed_files" "$total_files"
+                        continue
+                fi
 
-		truncated=${oldname:0:40}
+                truncated=${oldname:0:40}
 
 		# Skip hidden files that begin with a dot (e.g., .DS_Store, .htaccess)
 		# to avoid generating renamed copies of metadata files.
-		if [[ "$oldname" == .* && "$oldname" != "." && "$oldname" != ".." ]]; then
-			((num_files_unchanged++))
-			((processed_files++))
-			echo "$processed_files out of $total_files files complete"
-			continue
-		fi
+                if [[ "$oldname" == .* && "$oldname" != "." && "$oldname" != ".." ]]; then
+                        ((num_files_unchanged++))
+                        ((processed_files++))
+                        print_progress_line "$processed_files" "$total_files"
+                        continue
+                fi
 
-		if [[ "$oldname" == *.* && "$oldname" != .* ]]; then
+                if [[ "$oldname" == *.* && "$oldname" != .* ]]; then
 			base="${truncated%.*}"
 			extension=$(echo "${oldname##*.}" | tr '[:upper:]' '[:lower:]')
 		else
@@ -120,46 +159,55 @@ rename_files() {
 			temp_file="$dir/$tempname"
 		fi
 
-		if [[ $len -gt 1 && $target_name != "$oldname" ]]; then
-			for matchfile in "$dir"/*; do
-				matchname="${matchfile##*/}"
-				if [[ "$matchname" == "$target_name" ]]; then
-					overlapfile=1
+                if [[ $len -gt 1 && $target_name != "$oldname" ]]; then
+                        for matchfile in "$dir"/*; do
+                                matchname="${matchfile##*/}"
+                                if [[ "$matchname" == "$target_name" ]]; then
+                                        overlapfile=1
 				fi
 			done
 
 			cp -p "$file" "$temp_file"
 			rm -f "$file"
 
-			if [ $overlapfile -eq 0 ]; then
-				final_path="$dir/$target_name"
-				cp -p "$temp_file" "$final_path"
-				rm -f "$temp_file"
-				echo "file renamed to $final_path"
-				((num_files_renamed++))
-			else
-				((num_files_renamed++))
-				((countfile++))
+                        if [ $overlapfile -eq 0 ]; then
+                                final_path="$dir/$target_name"
+                                cp -p "$temp_file" "$final_path"
+                                rm -f "$temp_file"
+                                clear_progress_line
+                                echo "file renamed to $final_path"
+                                ((num_files_renamed++))
+                        else
+                                ((num_files_renamed++))
+                                ((countfile++))
 				target_name="${shortnewname}-${timestamp}${countfile}"
 				if [ -n "$extension" ]; then
 					final_path="$dir/$target_name.$extension"
-				else
-					final_path="$dir/$target_name"
-				fi
-				cp -p "$temp_file" "$final_path"
-				rm -f "$temp_file"
-				echo "file renamed to $final_path"
-			fi
-		else
-			((num_files_unchanged++))
-		fi
-		((processed_files++))
-		echo "$processed_files out of $total_files files complete"
-	done <"$tmpfile"
+                                else
+                                        final_path="$dir/$target_name"
+                                fi
+                                cp -p "$temp_file" "$final_path"
+                                rm -f "$temp_file"
+                                clear_progress_line
+                                echo "file renamed to $final_path"
+                        fi
+                else
+                        ((num_files_unchanged++))
+                fi
+                ((processed_files++))
+                print_progress_line "$processed_files" "$total_files"
+        done <"$tmpfile"
 
-	rm -f "$tmpfile"
+        rm -f "$tmpfile"
 
-	echo "..."
+        if [ "$total_files" -gt 0 ]; then
+                print_progress_line "$processed_files" "$total_files"
+        else
+                print_progress_line 0 0
+        fi
+        printf '\n'
+
+        echo "..."
 	echo "FILE RENAME COMPLETE"
 	echo "files renamed: $num_files_renamed"
 	echo "files unchanged: $num_files_unchanged"


### PR DESCRIPTION
## Summary
- add helper functions to render a single-line progress bar for file renames
- update rename loop to clear and redraw the counter without flooding the terminal

## Testing
- bash -n renamer.sh

------
https://chatgpt.com/codex/tasks/task_e_68ec71985e58832ab4c0f6f871d5be65